### PR TITLE
Keeping TLS version configurable in the template

### DIFF
--- a/arm-template-deployment/deployRGParent.json
+++ b/arm-template-deployment/deployRGParent.json
@@ -82,7 +82,23 @@
         "description": "Enable Activity logs to be sent to the event hub that will get created in this deployment"
       },
       "defaultValue": "Yes"
+    },
+    "TLSVersionStorageAccount": {
+      "type": "string",
+      "defaultValue": "1_2",
+      "metadata": {
+        "description": "Provide an appropriate TLS version for storage account. Format - X_X"
+      }
+    },
+    "TLSVersionFunctionApp": {
+      "type": "string",
+      "defaultValue": "1.3",
+      "metadata": {
+        "description": "Provide an appropriate TLS version for function app. Format - X.X"
+      }
     }
+
+
   },
   "resources": [
     {
@@ -138,6 +154,12 @@
           },
           "Resource_Type": {
             "value": "[parameters('Resource_Type')]"
+          },
+          "TLSVersionStorageAccount": {
+            "value": "[parameters('TLSVersionStorageAccount')]"
+          },
+          "TLSVersionFunctionApp": {
+            "value": "[parameters('TLSVersionFunctionApp')]"
           }
         }
       },

--- a/arm-template-deployment/deployResourcesInRG.json
+++ b/arm-template-deployment/deployResourcesInRG.json
@@ -34,6 +34,12 @@
     },
     "Resource_Type": {
       "type": "string"
+    },
+    "TLSVersionStorageAccount" : {
+      "type"  : "string"
+    },
+    "TLSVersionFunctionApp" : {
+      "type" : "string"
     }
   },
   "variables": {
@@ -46,7 +52,8 @@
     "functionServerfarms": "[concat(variables('eventhubNamespace'),'-service-plan')]",
     "listener": "listener",
     "sender": "sender",
-    "lm_auth": "[concat('{ \"LM_ACCESS_ID\" : \"',parameters('LM_Access_Id'),'\", \"LM_ACCESS_KEY\" : \"', parameters('LM_Access_Key'), '\", \"LM_BEARER_TOKEN\" : \"', parameters('LM_Bearer_Token'), '\" }')]"
+    "lm_auth": "[concat('{ \"LM_ACCESS_ID\" : \"',parameters('LM_Access_Id'),'\", \"LM_ACCESS_KEY\" : \"', parameters('LM_Access_Key'), '\", \"LM_BEARER_TOKEN\" : \"', parameters('LM_Bearer_Token'), '\" }')]",
+    "tlsVersionStorageAccount" : "[concat('TLS',parameters('TLSVersionStorageAccount'))]"
   },
   "resources": [
     {
@@ -74,7 +81,7 @@
       "apiVersion": "2019-06-01",
       "location": "[resourceGroup().location]",
       "properties": {
-        "minimumTlsVersion": "TLS1_2",
+        "minimumTlsVersion": "[variables('tlsVersionStorageAccount')]",
         "encryption": {
           "services": {
             "file": {
@@ -209,7 +216,8 @@
               "name": "RESOURCE_TYPE",
               "value": "[Parameters('Resource_Type')]"
             }
-          ]
+          ],
+          "minTlsVersion" : "[parameters('TLSVersionFunctionApp')]"
         }
       },
       "dependsOn": [


### PR DESCRIPTION
Added two new fields for TLS versions and passed on to the child template.

Keeping TLS version configurable in the template

tls configurable in storage acc and function app

passed tlsVersions to dependent template

moved tls inside siteConfig for func app

removed variable for tlsVersion function app, using parameter directly